### PR TITLE
Adds Bayesian plots to Python

### DIFF
--- a/RATapi/utils/plotting.py
+++ b/RATapi/utils/plotting.py
@@ -649,8 +649,8 @@ def plot_hist_panel(
         params = list(map(name_to_index, params))
 
     if estimated_density is not None:
+        temp = {}  # as dictionary cannot change size during iteration
         for key, value in estimated_density.items():
-            temp = {}  # as dictionary cannot change size during iteration
             temp[name_to_index(key)] = value
         estimated_density = temp
     else:

--- a/RATapi/utils/plotting.py
+++ b/RATapi/utils/plotting.py
@@ -328,7 +328,7 @@ def plot_hists(results: RATapi.outputs.BayesResults, block: bool = False, num_bi
         The number of bins to use for each histogram.
     """
     try:
-        _, nplots = results.chain.shape
+        chain = results.chain
         fit_names = results.fitNames
     except AttributeError as err:
         raise ValueError(
@@ -336,13 +336,14 @@ def plot_hists(results: RATapi.outputs.BayesResults, block: bool = False, num_bi
         ) from err
 
     # calculate grid size for grid of subplots
+    _, nplots = chain.shape
     nrows, ncols = ceil(sqrt(nplots)), floor(sqrt(nplots))
 
     fig = plt.subplots(nrows, ncols, figsize=(2 * nrows, 2.5 * ncols))[0]
     axs = fig.get_axes()
 
     for i in range(0, nplots):
-        counts, bins = np.histogram(results.chain[:, i], bins=num_bins, density=True)
+        counts, bins = np.histogram(chain[:, i], bins=num_bins, density=True)
         axs[i].hist(
             bins[:-1],
             bins,

--- a/RATapi/utils/plotting.py
+++ b/RATapi/utils/plotting.py
@@ -372,13 +372,15 @@ def plot_corner(
 
     fig, axes = plt.subplots(num_params, num_params, figsize=(2 * num_params, 2 * num_params))
     # i is row, j is column
-    for i in range(0, num_params):
-        for j in range(0, num_params):
+    for i, row_param in enumerate(params):
+        for j, col_param in enumerate(params):
             current_axes: Axes = axes[i][j]
             if i == j:  # diagonal: histograms
-                plot_hist(results, param=j, smooth=smooth, axes=current_axes, **hist_kwargs)
+                plot_hist(results, param=row_param, smooth=smooth, axes=current_axes, **hist_kwargs)
             elif i > j:  # lower triangle: 2d histograms
-                plot_contour(results, x_param=i, y_param=j, smooth=smooth, axes=current_axes, **hist2d_kwargs)
+                plot_contour(
+                    results, x_param=row_param, y_param=col_param, smooth=smooth, axes=current_axes, **hist2d_kwargs
+                )
             elif i < j:  # upper triangle: no plot
                 current_axes.set_visible(False)
             # remove label if on inside of corner plot

--- a/RATapi/utils/plotting.py
+++ b/RATapi/utils/plotting.py
@@ -361,3 +361,26 @@ def plot_hists(results: RATapi.outputs.BayesResults, block: bool = False, num_bi
     fig.show()
     if block:
         fig.wait_for_close()
+
+
+def plot_bayes(project: RATapi.Project, results: RATapi.outputs.BayesResults):
+    """Plot the results of a Bayesian analysis with confidence information.
+
+    This produces an unshaded reflectivity/SLD plot, a reflectivity/SLD plot with shaded 95% confidence
+    intervals, a grid of histograms giving probability density for each parameter, and a corner plot for
+    all parameters.
+
+    Parameters
+    project : Project
+              An instance of the Project class
+    results : Union[Results, BayesResults]
+              The result from the calculation
+    block : bool, default: False
+            Indicates the plot should block until it is closed
+
+    """
+
+    plot_ref_sld(project, results)
+    plot_ref_sld(project, results, bayes=95)
+    plot_hists(results)
+    plot_corner(results)

--- a/RATapi/utils/plotting.py
+++ b/RATapi/utils/plotting.py
@@ -3,6 +3,7 @@
 from functools import wraps
 from math import ceil, floor, sqrt
 from statistics import mean, stdev
+from textwrap import fill
 from typing import Callable, Literal, Optional, Union
 
 import matplotlib
@@ -218,6 +219,8 @@ def plot_ref_sld(
                 interval = [0, 4]
             elif bayes == 65:
                 interval = [1, 3]
+            else:
+                raise ValueError("Parameter `bayes` must be 95, 65 or None")
             confidence_intervals = {
                 "reflectivity": [
                     (ref_inter[interval[0]], ref_inter[interval[1]])
@@ -453,7 +456,8 @@ def plot_hist(
         linewidth=1.2,
         color="white",
     )
-    axes.set_title(results.fitNames[param])
+
+    axes.set_title(fill(results.fitNames[param], 20))  # use `fill` to wrap long titles
 
     if estimated_density:
         dx = bins[1] - bins[0]

--- a/RATapi/utils/plotting.py
+++ b/RATapi/utils/plotting.py
@@ -102,7 +102,9 @@ def plot_ref_sld_helper(
         # Plot confidence intervals if required
         if confidence_intervals is not None:
             ref_min, ref_max = confidence_intervals["reflectivity"][i]
-            ref_plot.fill_between(r[:, 0], ref_min / div, ref_max / div, alpha=0.6, color="grey")
+            # FIXME: remove x-data once rascalsoftware/RAT#249 is merged
+            ref_x_data = confidence_intervals["reflectivity-x-data"][i][0]
+            ref_plot.fill_between(ref_x_data, ref_min / div, ref_max / div, alpha=0.6, color="grey")
 
         if data.dataPresent[i]:
             sd_x = sd[:, 0]
@@ -126,7 +128,9 @@ def plot_ref_sld_helper(
         # Plot confidence intervals if required
         if confidence_intervals is not None:
             sld_min, sld_max = confidence_intervals["sld"][i][j]
-            sld_plot.fill_between(sld[j][:, 0], sld_min, sld_max, alpha=0.6, color="grey")
+            # FIXME: remove x-data once rascalsoftware/RAT#249 is merged
+            sld_x_data = confidence_intervals["sld-x-data"][i][j][0]
+            sld_plot.fill_between(sld_x_data, sld_min, sld_max, alpha=0.6, color="grey")
 
         if data.resample[i] == 1 or data.modelType == "custom xy":
             layers = data.resampledLayers[i][0]
@@ -228,6 +232,9 @@ def plot_ref_sld(
                     [(sld_inter[interval[0]], sld_inter[interval[1]]) for sld_inter in sld]
                     for sld in results.predictionIntervals.sld
                 ],
+                # FIXME: remove x-data once rascalsoftware/RAT#249 is merged
+                "reflectivity-x-data": results.predictionIntervals.reflectivityXData,
+                "sld-x-data": results.predictionIntervals.sldXData,
             }
         else:
             raise ValueError(

--- a/RATapi/utils/plotting.py
+++ b/RATapi/utils/plotting.py
@@ -321,7 +321,7 @@ def panel_plot_helper(plot_func: Callable, indices: list[int]) -> matplotlib.fig
     Parameters
     ----------
     plot_func : Callable
-        A function to create an Axes object with the plot for one parameter, given its index.
+        A function which plots one parameter on an Axes object, given its index.
 
     """
     nplots = len(indices)
@@ -426,6 +426,25 @@ def plot_chain(
     fig.show()
     if block:
         fig.wait_for_close()
+
+
+def plot_contour(results: RATapi.outputs.BayesResults, idx1: int, idx2: int):
+    """Plot a 2D histogram of two indexed parameters.
+
+    Parameters
+    ----------
+    results: RATapi.outputs.BayesResults
+        The results of a Bayesian analysis.
+    idx1: int
+        The index of the parameter on the x-axis.
+    idx2: int
+        The index of the parameter on the y-axis.
+    """
+
+    ax = plt.subplots(1, 1)[1]
+    corner.hist2d(results.chain[:, idx1], results.chain[:, idx2])
+    ax.set_xlabel(results.fitNames[idx1])
+    ax.set_ylabel(results.fitNames[idx2])
 
 
 def plot_bayes(project: RATapi.Project, results: RATapi.outputs.BayesResults):

--- a/RATapi/utils/plotting.py
+++ b/RATapi/utils/plotting.py
@@ -2,7 +2,7 @@
 
 from functools import wraps
 from math import ceil, floor, sqrt
-from statistics import mean, stdev
+from statistics import stdev
 from textwrap import fill
 from typing import Callable, Literal, Optional, Union
 
@@ -481,8 +481,8 @@ def plot_one_hist(
 
     parameter_chain = chain[:, param]
     counts, bins = np.histogram(parameter_chain, **hist_settings)
-    mean_y = mean(parameter_chain)
-    sd_y = stdev(parameter_chain)
+    mean_y = np.mean(parameter_chain)
+    sd_y = np.std(parameter_chain)
 
     if smooth:
         if sigma is None:
@@ -506,7 +506,7 @@ def plot_one_hist(
             axes.plot(t, norm.pdf(t, loc=mean_y, scale=sd_y**2))
         elif estimated_density == "lognor":
             t = np.linspace(bins[0] - 0.5 * dx, bins[-1] + 2 * dx)
-            axes.plot(t, lognorm.pdf(t, mean(np.log(parameter_chain)), stdev(np.log(parameter_chain))))
+            axes.plot(t, lognorm.pdf(t, np.mean(np.log(parameter_chain)), np.std(np.log(parameter_chain))))
         elif estimated_density == "kernel":
             t = np.linspace(bins[0] - 2 * dx, bins[-1] + 2 * dx, 200)
             kde = gaussian_kde(parameter_chain)
@@ -703,11 +703,12 @@ def plot_hists(
                 raise IndexError(f"Index {param} has been given, but indices must be between zero and {len(names)}.")
         else:
             raise ValueError(f"Parameters must be given as indices or names, not {type(param)}.")
+        return param
 
     if params is None:
         params = range(0, len(results.fitNames))
     else:
-        params = map(name_to_index, params)
+        params = list(map(name_to_index, params))
 
     if estimated_density is not None:
         default = estimated_density.get("default")

--- a/RATapi/utils/plotting.py
+++ b/RATapi/utils/plotting.py
@@ -288,27 +288,17 @@ class LivePlot:
             plt.show(block=self.block)
 
 
-def assert_bayesian(name: str, takes_project: bool = False):
+def assert_bayesian(name: str):
     """Decorator to ensure the results passed to a function are Bayesian.
 
     Parameters
     ----------
     name : str
         The name of the plot for the error message.
-    takes_project : bool
-        Whether the first variable of the plot is 'project'
-        (as in plot_bayes) or 'results' (as in most plots)
+
     """
 
     def decorator(func: Callable):
-        if takes_project:
-
-            @wraps(func)
-            def inner(project, results, *args, **kwargs):
-                if isinstance(results, RATapi.outputs.BayesResults):
-                    return func(project, results, *args, **kwargs)
-                raise ValueError(f"{name} plots are only available for the results of Bayesian analysis (NS or DREAM)")
-
         @wraps(func)
         def inner(results, *args, **kwargs):
             if isinstance(results, RATapi.outputs.BayesResults):
@@ -693,7 +683,6 @@ def plot_chain_panel(
         fig.wait_for_close()
 
 
-@assert_bayesian(name="Bayes", takes_project=True)
 def plot_bayes(project: RATapi.Project, results: RATapi.outputs.BayesResults):
     """Plot the results of a Bayesian analysis with confidence information.
 
@@ -710,7 +699,10 @@ def plot_bayes(project: RATapi.Project, results: RATapi.outputs.BayesResults):
             Indicates the plot should block until it is closed
 
     """
-    plot_ref_sld(project, results)
-    plot_ref_sld(project, results, bayes=95)
-    plot_hist_panel(results)
-    plot_corner(results)
+    if isinstance(results, RATapi.outputs.BayesResults):
+        plot_ref_sld(project, results)
+        plot_ref_sld(project, results, bayes=95)
+        plot_hist_panel(results)
+        plot_corner(results)
+    else:
+        raise ValueError("Bayes plots are only available for the results of Bayesian analysis (NS or DREAM)")

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ matplotlib >= 3.8.3
 StrEnum >= 0.4.15; python_version < '3.11'
 ruff >= 0.4.10
 corner >= 2.2.2
+scipy >= 1.14.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,4 +8,4 @@ matplotlib >= 3.8.3
 StrEnum >= 0.4.15; python_version < '3.11'
 ruff >= 0.4.10
 corner >= 2.2.2
-scipy >= 1.14.0
+scipy >= 1.13.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,5 +7,4 @@ pytest-cov >= 4.1.0
 matplotlib >= 3.8.3
 StrEnum >= 0.4.15; python_version < '3.11'
 ruff >= 0.4.10
-corner >= 2.2.2
 scipy >= 1.13.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ pytest-cov >= 4.1.0
 matplotlib >= 3.8.3
 StrEnum >= 0.4.15; python_version < '3.11'
 ruff >= 0.4.10
+corner >= 2.2.2

--- a/setup.py
+++ b/setup.py
@@ -165,7 +165,14 @@ setup(
     libraries=[libevent],
     ext_modules=ext_modules,
     python_requires=">=3.9",
-    install_requires=["numpy >= 1.20", "prettytable >= 3.9.0", "pydantic >= 2.7.2", "matplotlib >= 3.8.3"],
+    install_requires=[
+        "numpy >= 1.20",
+        "prettytable >= 3.9.0",
+        "pydantic >= 2.7.2",
+        "matplotlib >= 3.8.3",
+        "corner >= 2.2.2",
+        "scipy >= 1.14.0",
+    ],
     extras_require={
         ':python_version < "3.11"': ["StrEnum >= 0.4.15"],
         "Dev": ["pytest>=7.4.0", "pytest-cov>=4.1.0", "ruff>=0.4.10"],

--- a/setup.py
+++ b/setup.py
@@ -170,7 +170,6 @@ setup(
         "prettytable >= 3.9.0",
         "pydantic >= 2.7.2",
         "matplotlib >= 3.8.3",
-        "corner >= 2.2.2",
         "scipy >= 1.13.1",
     ],
     extras_require={

--- a/setup.py
+++ b/setup.py
@@ -171,7 +171,7 @@ setup(
         "pydantic >= 2.7.2",
         "matplotlib >= 3.8.3",
         "corner >= 2.2.2",
-        "scipy >= 1.14.0",
+        "scipy >= 1.13.1",
     ],
     extras_require={
         ':python_version < "3.11"': ["StrEnum >= 0.4.15"],

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -440,14 +440,15 @@ def test_standardise_est_dens(mock_plot_hist: MagicMock, input, expected_dict, d
     est_dens_dict = {keys_called[i]: est_density[i] for i in range(0, len(keys_called))}
 
     assert expected_dict == est_dens_dict
+    plt.close("all")
 
 
 @pytest.mark.parametrize("input", [{250: "lognor"}, {"Oxide Quickness": "normal"}, {"D2O": "Rattian"}, {-5: "lognor"}])
 def test_est_dens_error(dream_results, input):
     """Ensure a bad estimated density input raises an error."""
-    # the error message contains the phrase "parameter {key}" in both cases, so use that
+    # the error message contains the phrase "Parameter {key}" or "Index {key}", so use that
     # to ensure we're not getting some random ValueError
-    with pytest.raises(ValueError, match=f"[P|p]arameter {(list(input.keys())[0])}"):
+    with pytest.raises((ValueError, IndexError), match=f"Parameter|Index {(list(input.keys())[0])}"):
         RATplot.plot_hists(dream_results, estimated_density=input)
 
 

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -1,13 +1,18 @@
 import os
 import pickle
+from math import ceil, sqrt
+from textwrap import fill
 from unittest.mock import MagicMock, patch
 
 import matplotlib.pyplot as plt
+import numpy as np
 import pytest
+from matplotlib.collections import QuadMesh
+from matplotlib.patches import Rectangle
 
+import RATapi.utils.plotting as RATplot
 from RATapi.events import notify
 from RATapi.rat_core import EventTypes, PlotEventData
-from RATapi.utils.plotting import LivePlot, plot_ref_sld, plot_ref_sld_helper
 
 TEST_DIR_PATH = os.path.join(os.path.dirname(os.path.realpath(__file__)), "test_data")
 
@@ -46,7 +51,7 @@ def fig(request) -> plt.figure:
     """Creates the fixture for the tests."""
     plt.close("all")
     figure = plt.subplots(1, 3)[0]
-    return plot_ref_sld_helper(fig=figure, data=domains_data() if request.param else data())
+    return RATplot.plot_ref_sld_helper(fig=figure, data=domains_data() if request.param else data())
 
 
 @pytest.mark.parametrize("fig", [False, True], indirect=True)
@@ -110,7 +115,7 @@ def test_sld_profile_function_call(mock: MagicMock) -> None:
     """Tests the makeSLDProfileXY function called with
     correct args.
     """
-    plot_ref_sld_helper(data())
+    RATplot.plot_ref_sld_helper(data())
 
     assert mock.call_count == 3
     assert mock.call_args_list[0].args[0] == 2.07e-06
@@ -136,7 +141,7 @@ def test_sld_profile_function_call(mock: MagicMock) -> None:
 def test_live_plot(mock: MagicMock) -> None:
     plot_data = data()
 
-    with LivePlot() as figure:
+    with RATplot.LivePlot() as figure:
         assert len(figure.axes) == 2
         notify(EventTypes.Plot, plot_data)
         plt.close(figure)
@@ -164,7 +169,7 @@ def test_live_plot(mock: MagicMock) -> None:
 
 @patch("RATapi.utils.plotting.plot_ref_sld_helper")
 def test_plot_ref_sld(mock: MagicMock, input_project, reflectivity_calculation_results) -> None:
-    plot_ref_sld(input_project, reflectivity_calculation_results)
+    RATplot.plot_ref_sld(input_project, reflectivity_calculation_results)
     mock.assert_called_once()
     data = mock.call_args[0][0]
     figure = mock.call_args[0][1]
@@ -181,3 +186,207 @@ def test_plot_ref_sld(mock: MagicMock, input_project, reflectivity_calculation_r
     assert (data.subRoughs == reflectivity_calculation_results.contrastParams.subRoughs).all()
     assert data.resample.size == 0
     assert len(data.contrastNames) == 0
+
+
+@patch("RATapi.utils.plotting.plot_ref_sld_helper")
+def test_plot_ref_sld_bayes_validation(mock, input_project, reflectivity_calculation_results, dream_results):
+    """Test that plot_ref_sld correctly throws errors for bad Bayesian input."""
+    RATplot.plot_ref_sld(input_project, dream_results)
+    RATplot.plot_ref_sld(input_project, dream_results, bayes=65)
+    RATplot.plot_ref_sld(input_project, dream_results, bayes=95)
+    with pytest.raises(ValueError):
+        RATplot.plot_ref_sld(input_project, reflectivity_calculation_results, bayes=65)
+    with pytest.raises(ValueError):
+        RATplot.plot_ref_sld(input_project, dream_results, bayes=15)
+
+
+def test_assert_bayesian(dream_results, reflectivity_calculation_results):
+    """Test that the `assert_bayesian` decorator validates correctly."""
+
+    @RATplot.assert_bayesian("test")
+    def test_plot(results):
+        pass
+
+    test_plot(dream_results)
+    with pytest.raises(ValueError):
+        test_plot(reflectivity_calculation_results)
+
+
+@pytest.mark.parametrize("indices", [[0, 1, 2, 3, 4], [2, 5, 11], [8]])
+def test_panel_helper(indices):
+    """Test that the panel plot helper creates a panel with the expected subplots."""
+
+    def plot_func(axes, k):
+        """Plot k lines on an Axes."""
+        for i in range(0, k):
+            axes.plot([i], [i])
+
+    nplots = len(indices)
+
+    fig = RATplot.panel_plot_helper(plot_func, indices)
+    # ensure correct number of axes were created
+    expected_num_axes = ceil(sqrt(nplots)) * round(sqrt(nplots))
+    assert len(fig.axes) == expected_num_axes
+
+    # assert all required axes are visible and have the requested number of lines
+    for i, index in enumerate(indices):
+        assert len(fig.axes[i].get_lines()) == index
+        assert fig.axes[i].get_visible()
+
+    # assert remaining axes are not visible
+    for i in range(nplots, expected_num_axes):
+        assert fig.axes[i].get_visible() is False
+
+
+@pytest.mark.parametrize("param", ["CW Thickness", "D2O", 5])
+@pytest.mark.parametrize("hist_settings", [{}, {"bins": 18}, {"density": False, "range": (0, 5)}])
+@pytest.mark.parametrize("est_dens", [None, "normal", "lognor", "kernel"])
+def test_hist(dream_results, param, hist_settings, est_dens):
+    """Tests the formatting of the histogram plot."""
+    fig: plt.Figure = RATplot.plot_hist(
+        dream_results, param, estimated_density=est_dens, **hist_settings, return_fig=True
+    )
+    ax = fig.axes[0]
+    components = ax.get_children()
+
+    # assert expected number of bins including default
+    # this ensures default hist_settings are overwritten correctly
+    # +1 rectangle because the bounds of the plot is a rectangle
+    expected_bins = hist_settings.get("bins", 25) + 1
+    assert len([c for c in components if isinstance(c, Rectangle)]) == expected_bins
+
+    # assert line is only drawn if estimated density given
+    assert len(ax.get_lines()) == (0 if est_dens is None else 1)
+
+    # assert title is as expected
+    # also tests string to index conversion
+    assert ax.get_title() == fill(dream_results.fitNames[param] if isinstance(param, int) else param, 20)
+
+    # assert range is default, unless given
+    # this tests non-default hist_settings propagates correctly
+    try:
+        expected_range = hist_settings["range"]
+    except KeyError:  # if no range given, compute the automatic range
+        param_index = dream_results.fitNames.index(param) if isinstance(param, str) else param
+        param_chain = dream_results.chain[:, param_index]
+        expected_range = (param_chain.min(), param_chain.max())
+    assert ax.get_xbound() == expected_range
+
+
+@pytest.mark.parametrize(["x_param", "y_param"], [["CW Thickness", "D2O"], ["Bilayer Heads Thickness", 5], [2, 7]])
+@pytest.mark.parametrize("hist2d_settings", [{}, {"bins": 15}, {"range": [(0.0, 5.0), (1.0, 2.0)]}])
+def test_contour(dream_results, x_param, y_param, hist2d_settings):
+    """Test the formatting of the contour plot."""
+    fig: plt.Figure = RATplot.plot_contour(dream_results, x_param, y_param, return_fig=True, **hist2d_settings)
+    ax = fig.axes[0]
+    components = ax.get_children()
+
+    # assert expected number of bins including default
+    # this ensures default hist2d_settings are overwritten correctly
+    # +1 as we are counting edges in this case
+    expected_bins = hist2d_settings.get("bins", 25) + 1
+    quad_mesh = [c for c in components if isinstance(c, QuadMesh)][0]
+    assert quad_mesh._coordinates.shape == (expected_bins, expected_bins, 2)
+
+    # assert correct axis labels
+    # this ensures string to index conversion works
+    assert ax.get_xlabel() == (dream_results.fitNames[x_param] if isinstance(x_param, int) else x_param)
+    assert ax.get_ylabel() == (dream_results.fitNames[y_param] if isinstance(y_param, int) else y_param)
+
+    # assert range is default, unless given
+    # this tests non-default hist2d_settings propagates correctly
+    try:
+        x_expected_range, y_expected_range = hist2d_settings["range"]
+    except KeyError:  # if no range given, compute the automatic range
+        x_param_index = dream_results.fitNames.index(x_param) if isinstance(x_param, str) else x_param
+        y_param_index = dream_results.fitNames.index(y_param) if isinstance(y_param, str) else y_param
+        x_param_chain = dream_results.chain[:, x_param_index]
+        y_param_chain = dream_results.chain[:, y_param_index]
+        x_expected_range = (x_param_chain.min(), x_param_chain.max())
+        y_expected_range = (y_param_chain.min(), y_param_chain.max())
+    assert ax.get_xbound() == y_expected_range
+    assert ax.get_ybound() == x_expected_range
+
+
+@pytest.mark.parametrize(
+    "params",
+    [
+        None,
+        ["Bilayer Heads Thickness", "Bilayer Heads Hydration", "D2O"],
+        ["Bilayer Heads Thickness", 2, 3, "D2O", 5],
+        [1, 2, 3, 4, 5],
+    ],
+)
+def test_corner(dream_results, params):
+    """Test that corner plots are formatted correctly."""
+    # no use testing hist_settings and hist2d_settings here as they're tested above
+    fig: plt.Figure = RATplot.plot_corner(dream_results, params, return_fig=True)
+    axes = fig.axes
+    if params is None:
+        params = range(0, len(dream_results.fitNames))
+    assert len(axes) == len(params) ** 2
+    # annoyingly, fig.axes doesn't preserve the grid shape from plt.subplots... reconstruct grid
+    axes = np.array([axes[i : i + len(params)] for i in range(0, len(axes), len(params))])
+
+    for i in range(0, len(params)):
+        for j in range(0, len(params)):
+            current_axes = axes[i][j]
+            # ensure upper triangle is invisible
+            if i < j:
+                assert current_axes.get_visible() is False
+            elif i > j:
+                # check axes are the same along each row and column for contours
+                assert current_axes.get_ybound() == axes[i][0].get_ybound()
+                assert current_axes.get_xbound() == axes[-1][j].get_xbound()
+            elif i == j:
+                # check title is correct
+                assert current_axes.get_title() == fill(
+                    dream_results.fitNames[params[i]] if isinstance(params[i], int) else params[i], 20
+                )
+
+
+@pytest.mark.parametrize(
+    "params", [None, [2, 3], [1, 5, "D2O"], ["Bilayer Heads Thickness", "Bilayer Heads Hydration", "D2O"]]
+)
+@patch("RATapi.plotting.panel_plot_helper")
+def test_hist_panel(mock_panel_helper: MagicMock, params, dream_results):
+    """Test chain panel name-to-index (panel helper has already been tested)"""
+    RATplot.plot_hist_panel(dream_results, params)
+    if params is None:
+        params = range(0, len(dream_results.fitNames))
+
+    for param in mock_panel_helper.call_args()[1]:
+        assert param == (dream_results.fitNames.index(param) if isinstance(param, str) else param)
+
+
+@pytest.mark.parametrize(
+    "params", [None, [2, 3], [1, 5, "D2O"], ["Bilayer Heads Thickness", "Bilayer Heads Hydration", "D2O"]]
+)
+@patch("RATapi.plotting.panel_plot_helper")
+def test_chain_panel(mock_panel_helper: MagicMock, params, dream_results):
+    """Test chain panel name-to-index (panel helper has already been tested)"""
+    RATplot.plot_chain_panel(dream_results, params)
+    if params is None:
+        params = range(0, len(dream_results.fitNames))
+
+    for param in mock_panel_helper.call_args()[1]:
+        assert param == (dream_results.fitNames.index(param) if isinstance(param, str) else param)
+
+
+@patch("RATapi.plotting.plot_ref_sld")
+@patch("RATapi.plotting.plot_hist_panel")
+@patch("RATapi.plotting.plot_corner")
+def test_bayes_calls(
+    mock_corner: MagicMock, mock_hist_panel: MagicMock, mock_ref_sld: MagicMock, input_project, dream_results
+):
+    """Test that the Bayes plot calls the required plotting subroutines."""
+    RATplot.plot_bayes(input_project, dream_results)
+    assert mock_ref_sld.call_count == 2
+    mock_hist_panel.assert_called_once()
+    mock_corner.assert_called_once()
+
+
+def test_bayes_validation(input_project, reflectivity_calculation_results):
+    """Ensure that plot_bayes fails if given regular Results."""
+    with pytest.raises(ValueError):
+        RATplot.plot_bayes(input_project, reflectivity_calculation_results)

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -392,7 +392,9 @@ def test_hist_panel(mock_panel_helper: MagicMock, params, dream_results):
     if params is None:
         params = range(0, len(dream_results.fitNames))
 
-    for param in mock_panel_helper.call_args()[1]:
+    passed_params = mock_panel_helper.call_args.args[1]
+    assert len(passed_params) == len(params)
+    for param in passed_params:
         assert param == (dream_results.fitNames.index(param) if isinstance(param, str) else param)
 
 


### PR DESCRIPTION
This PR fixes #45 by adding the remaining plotting functionality from RAT to the Python API. These are:

- `cornerPlot` -> `plot_corner`
- `plotHists` -> `plot_hists`
- `bayesShadedPlot` -> new `bayes` parameter for `plot_ref_sld`
- `histp` -> `plot_one_hist` (with `estimated_density` parameter for estimated density overplot)
- `mcmcplot` -> `plot_chain`
- `plotBayes` -> `plot_bayes` (just calls `plot_ref_sld` with and without confidence intervals, `plot_hists` and `plot_corner`)