### PR TITLE
 raises NotImplementedError for data/function backgrounds 

### DIFF
--- a/RATapi/models.py
+++ b/RATapi/models.py
@@ -62,16 +62,17 @@ class Background(RATModel):
     value_4: str = ""
     value_5: str = ""
 
-    @model_validator(mode="after")
-    def validate_unimplemented_backgrounds(self):
+    @field_validator("type")
+    @classmethod
+    def validate_unimplemented_backgrounds(cls, type):
         """Raise an error if currently unsupported Data or Function backgrounds are used."""
         # FIXME: once data/function backgrounds have been implemented,
         # please remember to remove the @pytest.mark.skip decorators used to skip the tests:
         # - tests/test_project.py::test_check_allowed_background_resolution_values_data
         # - tests/test_project.py::test_check_allowed_background_resolution_values_on_data_list
-        if self.type == TypeOptions.Data:
+        if type == TypeOptions.Data:
             raise NotImplementedError("Data backgrounds are not yet supported.")
-        elif self.type == TypeOptions.Function:
+        elif type == TypeOptions.Function:
             raise NotImplementedError("Function backgrounds are not yet supported.")
 
 

--- a/RATapi/models.py
+++ b/RATapi/models.py
@@ -63,8 +63,12 @@ class Background(RATModel):
     value_5: str = ""
 
     @model_validator(mode="after")
-    def validate_background(self):
-        """Ensure that correct parameters have been given for the background type."""
+    def validate_unimplemented_backgrounds(self):
+        """Raise an error if currently unsupported Data or Function backgrounds are used."""
+        # FIXME: once data/function backgrounds have been implemented,
+        # please remember to remove the @pytest.mark.skip decorators used to skip the tests:
+        # - tests/test_project.py::test_check_allowed_background_resolution_values_data
+        # - tests/test_project.py::test_check_allowed_background_resolution_values_on_data_list
         if self.type == TypeOptions.Data:
             raise NotImplementedError("Data backgrounds are not yet supported.")
         elif self.type == TypeOptions.Function:

--- a/RATapi/models.py
+++ b/RATapi/models.py
@@ -64,7 +64,7 @@ class Background(RATModel):
 
     @field_validator("type")
     @classmethod
-    def validate_unimplemented_backgrounds(cls, type):
+    def validate_unimplemented_backgrounds(cls, type: TypeOptions):
         """Raise an error if currently unsupported Data or Function backgrounds are used."""
         # FIXME: once data/function backgrounds have been implemented,
         # please remember to remove the @pytest.mark.skip decorators used to skip the tests:
@@ -72,8 +72,9 @@ class Background(RATModel):
         # - tests/test_project.py::test_check_allowed_background_resolution_values_on_data_list
         if type == TypeOptions.Data:
             raise NotImplementedError("Data backgrounds are not yet supported.")
-        elif type == TypeOptions.Function:
+        if type == TypeOptions.Function:
             raise NotImplementedError("Function backgrounds are not yet supported.")
+        return type
 
 
 class Contrast(RATModel):

--- a/RATapi/models.py
+++ b/RATapi/models.py
@@ -62,6 +62,14 @@ class Background(RATModel):
     value_4: str = ""
     value_5: str = ""
 
+    @model_validator(mode="after")
+    def validate_background(self):
+        """Ensure that correct parameters have been given for the background type."""
+        if self.type == TypeOptions.Data:
+            raise NotImplementedError("Data backgrounds are not yet supported.")
+        elif self.type == TypeOptions.Function:
+            raise NotImplementedError("Function backgrounds are not yet supported.")
+
 
 class Contrast(RATModel):
     """Groups together all of the components of the model."""

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -958,6 +958,7 @@ def test_check_allowed_background_resolution_values_constant(test_value: str) ->
     )
 
 
+@pytest.mark.skip("Data backgrounds not currently supported.")
 @pytest.mark.parametrize(
     "test_value",
     [
@@ -999,6 +1000,7 @@ def test_check_allowed_background_resolution_values_not_on_constant_list(test_va
         )
 
 
+@pytest.mark.skip("Data backgrounds not currently supported.")
 @pytest.mark.parametrize(
     "test_value",
     [


### PR DESCRIPTION
Fixes #56 : A `NotImplementedError` is now raised if the user attempts to add a data or function background, as these backgrounds are not yet supported. I've also set Pytest to skip tests that use these backgrounds - if it's a better idea to remove them entirely then I will do that instead.