### PR TITLE
Changes control parameter `nMCMC` to int & fixes failing ruff lint

### DIFF
--- a/RATapi/controls.py
+++ b/RATapi/controls.py
@@ -60,7 +60,7 @@ class Controls(BaseModel, validate_assignment=True, extra="forbid"):
     numGenerations: int = Field(500, ge=1)
     # NS
     nLive: int = Field(150, ge=1)
-    nMCMC: float = Field(0.0, ge=0.0)
+    nMCMC: int = Field(0, ge=0)
     propScale: float = Field(0.1, gt=0.0, lt=1.0)
     nsTolerance: float = Field(0.1, ge=0.0)
     # Dream

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,7 @@ build-backend = 'setuptools.build_meta'
 
 [tool.ruff]
 line-length = 120
+extend-exclude = ["*.ipynb"]
 
 [tool.ruff.lint]
 select = ["E", "F", "UP", "B", "SIM", "I"]

--- a/tests/test_controls.py
+++ b/tests/test_controls.py
@@ -553,7 +553,7 @@ class TestNS:
             "|  resampleParams  | [0.9, 50] |\n"
             "|     display      |    iter   |\n"
             "|      nLive       |    150    |\n"
-            "|      nMCMC       |    0.0    |\n"
+            "|      nMCMC       |     0     |\n"
             "|    propScale     |    0.1    |\n"
             "|   nsTolerance    |    0.1    |\n"
             "+------------------+-----------+"
@@ -670,7 +670,7 @@ class TestNS:
     @pytest.mark.parametrize(
         "control_property, value, bound",
         [
-            ("nMCMC", -0.6, 0),
+            ("nMCMC", -1, 0),
             ("nsTolerance", -500, 0),
             ("nLive", -500, 1),
         ],


### PR DESCRIPTION
This PR changes the Control parameter `nMCMC` to an int. It is currently a `float` greater than or equal to zero, but if you set it to a non-integer value then the process hangs (because it is supposed to be an integer). It is a float in the C++ code, and `pybind11` automatically converts the integer to a float when the C++ Controls object is made: to test this you can try
```python
from RATapi.inputs import make_input
_, _, _, _, cpp_controls = make_input(problem, RAT.Controls(procedure="ns"))
print(cpp_controls.nMCMC)
```
and see that it prints 0.0.

Also fixes ruff linting as the latest ruff update made it lint jupyter notebooks by default.