### PR TITLE
Splits `resampleParams` into two parameters and bumps version to 0.0.0.dev2

### DIFF
--- a/RATapi/controls.py
+++ b/RATapi/controls.py
@@ -40,7 +40,7 @@ class Controls(BaseModel, validate_assignment=True, extra="forbid"):
     procedure: Procedures = Procedures.Calculate
     parallel: Parallel = Parallel.Single
     calcSldDuringFit: bool = False
-    resampleMinAngle: float = Field(0.9, lt=1, gt=0)
+    resampleMinAngle: float = Field(0.9, le=1, gt=0)
     resampleNPoints: int = Field(50, ge=0)
     display: Display = Display.Iter
     # Simplex

--- a/RATapi/controls.py
+++ b/RATapi/controls.py
@@ -41,7 +41,7 @@ class Controls(BaseModel, validate_assignment=True, extra="forbid"):
     parallel: Parallel = Parallel.Single
     calcSldDuringFit: bool = False
     resampleMinAngle: float = Field(0.9, le=1, gt=0)
-    resampleNPoints: int = Field(50, ge=0)
+    resampleNPoints: int = Field(50, gt=0)
     display: Display = Display.Iter
     # Simplex
     xTolerance: float = Field(1.0e-6, gt=0.0)

--- a/RATapi/examples/absorption/absorption.py
+++ b/RATapi/examples/absorption/absorption.py
@@ -150,7 +150,7 @@ def absorption():
     )
 
     # Now make a controls block and run the code
-    controls = RAT.Controls(parallel="contrasts", resampleParams=[0.9, 150.0])
+    controls = RAT.Controls(parallel="contrasts", resampleNPoints=150)
     problem, results = RAT.run(problem, controls)
 
     return problem, results

--- a/RATapi/inputs.py
+++ b/RATapi/inputs.py
@@ -436,7 +436,8 @@ def make_controls(input_controls: RATapi.Controls, checks: Checks) -> Control:
     controls.procedure = input_controls.procedure
     controls.parallel = input_controls.parallel
     controls.calcSldDuringFit = input_controls.calcSldDuringFit
-    controls.resampleParams = input_controls.resampleParams
+    controls.resampleMinAngle = input_controls.resampleMinAngle
+    controls.resampleNPoints = input_controls.resampleNPoints
     controls.display = input_controls.display
     # Simplex
     controls.xTolerance = input_controls.xTolerance

--- a/cpp/rat.cpp
+++ b/cpp/rat.cpp
@@ -509,7 +509,8 @@ struct Control {
     real_T propScale {};
     real_T nsTolerance {};
     boolean_T calcSldDuringFit {};
-    py::array_t<real_T> resampleParams;
+    real_T resampleMinAngle {};
+    real_T resampleNPoints {};
     real_T updateFreq {};
     real_T updatePlotFreq {};
     real_T nSamples {};
@@ -914,8 +915,8 @@ RAT::struct2_T createStruct2T(const Control& control)
     stringToRatArray(control.procedure, control_struct.procedure.data, control_struct.procedure.size);
     stringToRatArray(control.display, control_struct.display.data, control_struct.display.size);
     control_struct.xTolerance = control.xTolerance;
-    control_struct.resampleParams[0] = control.resampleParams.at(0);
-    control_struct.resampleParams[1] = control.resampleParams.at(1);
+    control_struct.resampleMinAngle = control.resampleMinAngle;
+    control_struct.resampleNPoints = control.resampleNPoints;
     stringToRatArray(control.boundHandling, control_struct.boundHandling.data, control_struct.boundHandling.size);
     control_struct.adaptPCR = control.adaptPCR;
     control_struct.checks = createStruct3(control.checks);
@@ -1616,7 +1617,8 @@ PYBIND11_MODULE(rat_core, m) {
         .def_readwrite("propScale", &Control::propScale)
         .def_readwrite("nsTolerance", &Control::nsTolerance)
         .def_readwrite("calcSldDuringFit", &Control::calcSldDuringFit)
-        .def_readwrite("resampleParams", &Control::resampleParams)
+        .def_readwrite("resampleMinAngle", &Control::resampleMinAngle)
+        .def_readwrite("resampleNPoints", &Control::resampleNPoints)
         .def_readwrite("updateFreq", &Control::updateFreq)
         .def_readwrite("updatePlotFreq", &Control::updatePlotFreq)
         .def_readwrite("nSamples", &Control::nSamples)

--- a/cpp/rat.cpp
+++ b/cpp/rat.cpp
@@ -1635,14 +1635,14 @@ PYBIND11_MODULE(rat_core, m) {
                 return py::make_tuple(ctrl.parallel, ctrl.procedure, ctrl.display, ctrl.xTolerance, ctrl.funcTolerance, 
                                       ctrl.maxFuncEvals, ctrl.maxIterations, ctrl.populationSize, ctrl.fWeight, ctrl.crossoverProbability, 
                                       ctrl.targetValue, ctrl.numGenerations, ctrl.strategy, ctrl.nLive, ctrl.nMCMC, ctrl.propScale, 
-                                      ctrl.nsTolerance, ctrl.calcSldDuringFit, ctrl.resampleParams, ctrl.updateFreq, ctrl.updatePlotFreq, 
-                                      ctrl.nSamples, ctrl.nChains, ctrl.jumpProbability, ctrl.pUnitGamma, ctrl.boundHandling, ctrl.adaptPCR, 
-                                      ctrl.IPCFilePath, ctrl.checks.fitParam, ctrl.checks.fitBackgroundParam, ctrl.checks.fitQzshift, 
-                                      ctrl.checks.fitScalefactor, ctrl.checks.fitBulkIn, ctrl.checks.fitBulkOut, 
+                                      ctrl.nsTolerance, ctrl.calcSldDuringFit, ctrl.resampleMinAngle, ctrl.resampleNPoints,
+                                      ctrl.updateFreq, ctrl.updatePlotFreq, ctrl.nSamples, ctrl.nChains, ctrl.jumpProbability, ctrl.pUnitGamma, 
+                                      ctrl.boundHandling, ctrl.adaptPCR, ctrl.IPCFilePath, ctrl.checks.fitParam, ctrl.checks.fitBackgroundParam, 
+                                      ctrl.checks.fitQzshift, ctrl.checks.fitScalefactor, ctrl.checks.fitBulkIn, ctrl.checks.fitBulkOut, 
                                       ctrl.checks.fitResolutionParam, ctrl.checks.fitDomainRatio);
             },
             [](py::tuple t) { // __setstate__
-                if (t.size() != 36)
+                if (t.size() != 37)
                     throw std::runtime_error("Encountered invalid state unpickling ProblemDefinition object!");
 
                 /* Create a new C++ instance */
@@ -1666,25 +1666,26 @@ PYBIND11_MODULE(rat_core, m) {
                 ctrl.propScale = t[15].cast<real_T>();
                 ctrl.nsTolerance = t[16].cast<real_T>();
                 ctrl.calcSldDuringFit = t[17].cast<boolean_T>();
-                ctrl.resampleParams = t[18].cast<py::array_t<real_T>>();
-                ctrl.updateFreq = t[19].cast<real_T>();
-                ctrl.updatePlotFreq = t[20].cast<real_T>();
-                ctrl.nSamples = t[21].cast<real_T>();
-                ctrl.nChains = t[22].cast<real_T>();
-                ctrl.jumpProbability = t[23].cast<real_T>();
-                ctrl.pUnitGamma = t[24].cast<real_T>();
-                ctrl.boundHandling = t[25].cast<std::string>();
-                ctrl.adaptPCR = t[26].cast<boolean_T>();
-                ctrl.IPCFilePath = t[27].cast<std::string>();
+                ctrl.resampleMinAngle = t[18].cast<real_T>();
+                ctrl.resampleNPoints = t[19].cast<real_T>();
+                ctrl.updateFreq = t[20].cast<real_T>();
+                ctrl.updatePlotFreq = t[21].cast<real_T>();
+                ctrl.nSamples = t[22].cast<real_T>();
+                ctrl.nChains = t[23].cast<real_T>();
+                ctrl.jumpProbability = t[24].cast<real_T>();
+                ctrl.pUnitGamma = t[25].cast<real_T>();
+                ctrl.boundHandling = t[26].cast<std::string>();
+                ctrl.adaptPCR = t[27].cast<boolean_T>();
+                ctrl.IPCFilePath = t[28].cast<std::string>();
                 
-                ctrl.checks.fitParam = t[28].cast<py::array_t<real_T>>(); 
-                ctrl.checks.fitBackgroundParam = t[29].cast<py::array_t<real_T>>(); 
-                ctrl.checks.fitQzshift = t[30].cast<py::array_t<real_T>>(); 
-                ctrl.checks.fitScalefactor = t[31].cast<py::array_t<real_T>>(); 
-                ctrl.checks.fitBulkIn = t[32].cast<py::array_t<real_T>>(); 
-                ctrl.checks.fitBulkOut = t[33].cast<py::array_t<real_T>>(); 
-                ctrl.checks.fitResolutionParam = t[34].cast<py::array_t<real_T>>(); 
-                ctrl.checks.fitDomainRatio = t[35].cast<py::array_t<real_T>>();
+                ctrl.checks.fitParam = t[29].cast<py::array_t<real_T>>(); 
+                ctrl.checks.fitBackgroundParam = t[30].cast<py::array_t<real_T>>(); 
+                ctrl.checks.fitQzshift = t[31].cast<py::array_t<real_T>>(); 
+                ctrl.checks.fitScalefactor = t[32].cast<py::array_t<real_T>>(); 
+                ctrl.checks.fitBulkIn = t[33].cast<py::array_t<real_T>>(); 
+                ctrl.checks.fitBulkOut = t[34].cast<py::array_t<real_T>>(); 
+                ctrl.checks.fitResolutionParam = t[35].cast<py::array_t<real_T>>(); 
+                ctrl.checks.fitDomainRatio = t[36].cast<py::array_t<real_T>>();
 
                 return ctrl;
             }));

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ from setuptools import Extension, find_packages, setup
 from setuptools.command.build_clib import build_clib
 from setuptools.command.build_ext import build_ext
 
-__version__ = "0.0.0.dev1"
+__version__ = "0.0.0.dev2"
 PACKAGE_NAME = "RATapi"
 
 with open("README.md") as f:

--- a/tests/test_controls.py
+++ b/tests/test_controls.py
@@ -47,7 +47,8 @@ class TestCalculate:
             "|    procedure     | calculate |\n"
             "|     parallel     |   single  |\n"
             "| calcSldDuringFit |   False   |\n"
-            "|  resampleParams  | [0.9, 50] |\n"
+            "| resampleMinAngle |    0.9    |\n"
+            "| resampleNPoints  |     50    |\n"
             "|     display      |    iter   |\n"
             "+------------------+-----------+"
         )
@@ -59,7 +60,8 @@ class TestCalculate:
         [
             ("parallel", Parallel.Single),
             ("calcSldDuringFit", False),
-            ("resampleParams", [0.9, 50]),
+            ("resampleMinAngle", 0.9),
+            ("resampleNPoints", 50),
             ("display", Display.Iter),
             ("procedure", Procedures.Calculate),
         ],
@@ -73,7 +75,8 @@ class TestCalculate:
         [
             ("parallel", Parallel.Points),
             ("calcSldDuringFit", True),
-            ("resampleParams", [0.2, 1]),
+            ("resampleMinAngle", 0.2),
+            ("resampleNPoints", 1),
             ("display", Display.Notify),
         ],
     )
@@ -180,31 +183,6 @@ class TestCalculate:
         with pytest.raises(pydantic.ValidationError, match="Input should be 'off', 'iter', 'notify' or 'final'"):
             self.calculate.display = value
 
-    @pytest.mark.parametrize(
-        "value, msg",
-        [
-            ([5.0], "List should have at least 2 items after validation, not 1"),
-            ([12, 13, 14], "List should have at most 2 items after validation, not 3"),
-        ],
-    )
-    def test_calculate_resampleParams_length_validation(self, value: list, msg: str) -> None:
-        """Tests the resampleParams setter length validation in Calculate class."""
-        with pytest.raises(pydantic.ValidationError, match=msg):
-            self.calculate.resampleParams = value
-
-    @pytest.mark.parametrize(
-        "value, msg",
-        [
-            ([1.0, 2], "Value error, resampleParams[0] must be between 0 and 1"),
-            ([0.5, -0.1], "Value error, resampleParams[1] must be greater than or equal to 0"),
-        ],
-    )
-    def test_calculate_resampleParams_value_validation(self, value: list, msg: str) -> None:
-        """Tests the resampleParams setter value validation in Calculate class."""
-        with pytest.raises(pydantic.ValidationError) as exp:
-            self.calculate.resampleParams = value
-        assert exp.value.errors()[0]["msg"] == msg
-
     def test_str(self, table_str) -> None:
         """Tests the Calculate model __str__."""
         assert self.calculate.__str__() == table_str
@@ -220,21 +198,22 @@ class TestSimplex:
     @pytest.fixture
     def table_str(self):
         table_str = (
-            "+------------------+-----------+\n"
-            "|     Property     |   Value   |\n"
-            "+------------------+-----------+\n"
-            "|    procedure     |  simplex  |\n"
-            "|     parallel     |   single  |\n"
-            "| calcSldDuringFit |   False   |\n"
-            "|  resampleParams  | [0.9, 50] |\n"
-            "|     display      |    iter   |\n"
-            "|    xTolerance    |   1e-06   |\n"
-            "|  funcTolerance   |   1e-06   |\n"
-            "|   maxFuncEvals   |   10000   |\n"
-            "|  maxIterations   |    1000   |\n"
-            "|    updateFreq    |     1     |\n"
-            "|  updatePlotFreq  |     20    |\n"
-            "+------------------+-----------+"
+            "+------------------+---------+\n"
+            "|     Property     |  Value  |\n"
+            "+------------------+---------+\n"
+            "|    procedure     | simplex |\n"
+            "|     parallel     |  single |\n"
+            "| calcSldDuringFit |  False  |\n"
+            "| resampleMinAngle |   0.9   |\n"
+            "| resampleNPoints  |    50   |\n"
+            "|     display      |   iter  |\n"
+            "|    xTolerance    |  1e-06  |\n"
+            "|  funcTolerance   |  1e-06  |\n"
+            "|   maxFuncEvals   |  10000  |\n"
+            "|  maxIterations   |   1000  |\n"
+            "|    updateFreq    |    1    |\n"
+            "|  updatePlotFreq  |    20   |\n"
+            "+------------------+---------+"
         )
 
         return table_str
@@ -244,7 +223,8 @@ class TestSimplex:
         [
             ("parallel", Parallel.Single),
             ("calcSldDuringFit", False),
-            ("resampleParams", [0.9, 50]),
+            ("resampleMinAngle", 0.9),
+            ("resampleNPoints", 50),
             ("display", Display.Iter),
             ("procedure", Procedures.Simplex),
             ("xTolerance", 1e-6),
@@ -264,7 +244,8 @@ class TestSimplex:
         [
             ("parallel", Parallel.Points),
             ("calcSldDuringFit", True),
-            ("resampleParams", [0.2, 1]),
+            ("resampleMinAngle", 0.2),
+            ("resampleNPoints", 1),
             ("display", Display.Notify),
             ("xTolerance", 4e-6),
             ("funcTolerance", 3e-4),
@@ -380,7 +361,8 @@ class TestDE:
             "|      procedure       |       de      |\n"
             "|       parallel       |     single    |\n"
             "|   calcSldDuringFit   |     False     |\n"
-            "|    resampleParams    |   [0.9, 50]   |\n"
+            "|   resampleMinAngle   |      0.9      |\n"
+            "|   resampleNPoints    |       50      |\n"
             "|       display        |      iter     |\n"
             "|    populationSize    |       20      |\n"
             "|       fWeight        |      0.5      |\n"
@@ -400,7 +382,8 @@ class TestDE:
         [
             ("parallel", Parallel.Single),
             ("calcSldDuringFit", False),
-            ("resampleParams", [0.9, 50]),
+            ("resampleMinAngle", 0.9),
+            ("resampleNPoints", 50),
             ("display", Display.Iter),
             ("procedure", Procedures.DE),
             ("populationSize", 20),
@@ -420,7 +403,8 @@ class TestDE:
         [
             ("parallel", Parallel.Points),
             ("calcSldDuringFit", True),
-            ("resampleParams", [0.2, 1]),
+            ("resampleMinAngle", 0.2),
+            ("resampleNPoints", 1),
             ("display", Display.Notify),
             ("populationSize", 20),
             ("fWeight", 0.3),
@@ -544,19 +528,20 @@ class TestNS:
     @pytest.fixture
     def table_str(self):
         table_str = (
-            "+------------------+-----------+\n"
-            "|     Property     |   Value   |\n"
-            "+------------------+-----------+\n"
-            "|    procedure     |     ns    |\n"
-            "|     parallel     |   single  |\n"
-            "| calcSldDuringFit |   False   |\n"
-            "|  resampleParams  | [0.9, 50] |\n"
-            "|     display      |    iter   |\n"
-            "|      nLive       |    150    |\n"
-            "|      nMCMC       |     0     |\n"
-            "|    propScale     |    0.1    |\n"
-            "|   nsTolerance    |    0.1    |\n"
-            "+------------------+-----------+"
+            "+------------------+--------+\n"
+            "|     Property     | Value  |\n"
+            "+------------------+--------+\n"
+            "|    procedure     |   ns   |\n"
+            "|     parallel     | single |\n"
+            "| calcSldDuringFit | False  |\n"
+            "| resampleMinAngle |  0.9   |\n"
+            "| resampleNPoints  |   50   |\n"
+            "|     display      |  iter  |\n"
+            "|      nLive       |  150   |\n"
+            "|      nMCMC       |   0    |\n"
+            "|    propScale     |  0.1   |\n"
+            "|   nsTolerance    |  0.1   |\n"
+            "+------------------+--------+"
         )
 
         return table_str
@@ -566,7 +551,8 @@ class TestNS:
         [
             ("parallel", Parallel.Single),
             ("calcSldDuringFit", False),
-            ("resampleParams", [0.9, 50]),
+            ("resampleMinAngle", 0.9),
+            ("resampleNPoints", 50),
             ("display", Display.Iter),
             ("procedure", Procedures.NS),
             ("nLive", 150),
@@ -584,7 +570,8 @@ class TestNS:
         [
             ("parallel", Parallel.Points),
             ("calcSldDuringFit", True),
-            ("resampleParams", [0.2, 1]),
+            ("resampleMinAngle", 0.2),
+            ("resampleNPoints", 1),
             ("display", Display.Notify),
             ("nLive", 1500),
             ("nMCMC", 1),
@@ -707,21 +694,22 @@ class TestDream:
     @pytest.fixture
     def table_str(self):
         table_str = (
-            "+------------------+-----------+\n"
-            "|     Property     |   Value   |\n"
-            "+------------------+-----------+\n"
-            "|    procedure     |   dream   |\n"
-            "|     parallel     |   single  |\n"
-            "| calcSldDuringFit |   False   |\n"
-            "|  resampleParams  | [0.9, 50] |\n"
-            "|     display      |    iter   |\n"
-            "|     nSamples     |   20000   |\n"
-            "|     nChains      |     10    |\n"
-            "| jumpProbability  |    0.5    |\n"
-            "|    pUnitGamma    |    0.2    |\n"
-            "|  boundHandling   |  reflect  |\n"
-            "|     adaptPCR     |    True   |\n"
-            "+------------------+-----------+"
+            "+------------------+---------+\n"
+            "|     Property     |  Value  |\n"
+            "+------------------+---------+\n"
+            "|    procedure     |  dream  |\n"
+            "|     parallel     |  single |\n"
+            "| calcSldDuringFit |  False  |\n"
+            "| resampleMinAngle |   0.9   |\n"
+            "| resampleNPoints  |    50   |\n"
+            "|     display      |   iter  |\n"
+            "|     nSamples     |  20000  |\n"
+            "|     nChains      |    10   |\n"
+            "| jumpProbability  |   0.5   |\n"
+            "|    pUnitGamma    |   0.2   |\n"
+            "|  boundHandling   | reflect |\n"
+            "|     adaptPCR     |   True  |\n"
+            "+------------------+---------+"
         )
 
         return table_str
@@ -731,7 +719,8 @@ class TestDream:
         [
             ("parallel", Parallel.Single),
             ("calcSldDuringFit", False),
-            ("resampleParams", [0.9, 50]),
+            ("resampleMinAngle", 0.9),
+            ("resampleNPoints", 50),
             ("display", Display.Iter),
             ("procedure", Procedures.DREAM),
             ("nSamples", 20000),
@@ -751,7 +740,8 @@ class TestDream:
         [
             ("parallel", Parallel.Points),
             ("calcSldDuringFit", True),
-            ("resampleParams", [0.2, 1]),
+            ("resampleMinAngle", 0.2),
+            ("resampleNPoints", 1),
             ("display", Display.Notify),
             ("nSamples", 500),
             ("nChains", 1000),

--- a/tests/test_inputs.py
+++ b/tests/test_inputs.py
@@ -474,7 +474,8 @@ def standard_layers_controls():
     controls.procedure = Procedures.Calculate
     controls.parallel = Parallel.Single
     controls.calcSldDuringFit = False
-    controls.resampleParams = [0.9, 50.0]
+    controls.resampleMinAngle = 0.9
+    controls.resampleNPoints = 50.0
     controls.display = Display.Iter
     controls.xTolerance = 1.0e-6
     controls.funcTolerance = 1.0e-6
@@ -519,7 +520,8 @@ def custom_xy_controls():
     controls.procedure = Procedures.Calculate
     controls.parallel = Parallel.Single
     controls.calcSldDuringFit = True
-    controls.resampleParams = [0.9, 50.0]
+    controls.resampleMinAngle = 0.9
+    controls.resampleNPoints = 50.0
     controls.display = Display.Iter
     controls.xTolerance = 1.0e-6
     controls.funcTolerance = 1.0e-6
@@ -874,6 +876,8 @@ def check_controls_equal(actual_controls, expected_controls) -> None:
         "procedure",
         "parallel",
         "calcSldDuringFit",
+        "resampleMinAngle",
+        "resampleNPoints",
         "display",
         "xTolerance",
         "funcTolerance",
@@ -909,8 +913,6 @@ def check_controls_equal(actual_controls, expected_controls) -> None:
         "fitDomainRatio",
     ]
 
-    # Check "resampleParams" separately as it is an array
-    assert (actual_controls.resampleParams == expected_controls.resampleParams).all()
     for field in controls_fields:
         assert getattr(actual_controls, field) == getattr(expected_controls, field)
     for field in checks_fields:


### PR DESCRIPTION
Fixes #69 by splitting `resampleParams` into `resampleMinAngle` and `resampleNPoints`. Also changes the validation for `resampleMinAngle` to match MATLAB and be mathematically sensible - now accepts values strictly greater than 0 and less than or equal to 1.