### PR TITLE
Modifies cells to make function handles pickleable

### DIFF
--- a/cpp/rat.cpp
+++ b/cpp/rat.cpp
@@ -446,7 +446,7 @@ struct Cells {
     py::list f11;
     py::list f12;
     py::list f13;
-    py::list f14;
+    py::object f14;
     py::list f15;
     py::list f16;
     py::list f17;
@@ -844,12 +844,13 @@ coder::array<RAT::cell_wrap_6, 2U> pyListToRatCellWrap6(py::list values)
     return result;
 }
 
-coder::array<RAT::cell_wrap_6, 2U> py_function_array_to_rat_cell_wrap_6(py::list values)
+coder::array<RAT::cell_wrap_6, 2U> py_function_array_to_rat_cell_wrap_6(py::object values)
 {
+    auto handles = py::cast<py::list>(values);
     coder::array<RAT::cell_wrap_6, 2U> result;
-    result.set_size(1, values.size());
+    result.set_size(1, handles.size());
     int32_T idx {0};
-    for (py::handle array: values)
+    for (py::handle array: handles)
     { 
         auto func = py::cast<py::function>(array);
         std::string func_ptr = convertPtr2String<CallbackInterface>(new Library(func));
@@ -1585,7 +1586,7 @@ PYBIND11_MODULE(rat_core, m) {
                 cell.f11 = t[10].cast<py::list>(); 
                 cell.f12 = t[11].cast<py::list>();
                 cell.f13 = t[12].cast<py::list>(); 
-                cell.f14 = t[13].cast<py::list>(); 
+                cell.f14 = t[13].cast<py::object>(); 
                 cell.f15 = t[14].cast<py::list>(); 
                 cell.f16 = t[15].cast<py::list>(); 
                 cell.f17 = t[16].cast<py::list>(); 

--- a/tests/test_inputs.py
+++ b/tests/test_inputs.py
@@ -624,25 +624,7 @@ def test_make_input(test_project, test_problem, test_cells, test_limits, test_pr
         "domainRatio",
     ]
 
-    mocked_matlab_future = mock.MagicMock()
-    mocked_engine = mock.MagicMock()
-    mocked_matlab_future.result.return_value = mocked_engine
-
-    with mock.patch.object(
-        RATapi.wrappers.MatlabWrapper,
-        "loader",
-        mocked_matlab_future,
-    ), mock.patch.object(RATapi.rat_core, "DylibEngine", mock.MagicMock()), mock.patch.object(
-        RATapi.inputs,
-        "get_python_handle",
-        mock.MagicMock(return_value=dummy_function),
-    ), mock.patch.object(
-        RATapi.wrappers.MatlabWrapper,
-        "getHandle",
-        mock.MagicMock(return_value=dummy_function),
-    ), mock.patch.object(RATapi.wrappers.DylibWrapper, "getHandle", mock.MagicMock(return_value=dummy_function)):
-        problem, cells, limits, priors, controls = make_input(test_project, RATapi.Controls())
-
+    problem, cells, limits, priors, controls = make_input(test_project, RATapi.Controls())
     problem = pickle.loads(pickle.dumps(problem))
     check_problem_equal(problem, test_problem)
     cells = pickle.loads(pickle.dumps(cells))
@@ -768,25 +750,7 @@ def test_make_cells(test_project, test_cells, request) -> None:
     """The cells object should be populated according to the input project object."""
     test_project = request.getfixturevalue(test_project)
     test_cells = request.getfixturevalue(test_cells)
-
-    mocked_matlab_future = mock.MagicMock()
-    mocked_engine = mock.MagicMock()
-    mocked_matlab_future.result.return_value = mocked_engine
-    with mock.patch.object(
-        RATapi.wrappers.MatlabWrapper,
-        "loader",
-        mocked_matlab_future,
-    ), mock.patch.object(RATapi.rat_core, "DylibEngine", mock.MagicMock()), mock.patch.object(
-        RATapi.inputs,
-        "get_python_handle",
-        mock.MagicMock(return_value=dummy_function),
-    ), mock.patch.object(
-        RATapi.wrappers.MatlabWrapper,
-        "getHandle",
-        mock.MagicMock(return_value=dummy_function),
-    ), mock.patch.object(RATapi.wrappers.DylibWrapper, "getHandle", mock.MagicMock(return_value=dummy_function)):
-        cells = make_cells(test_project)
-
+    cells = make_cells(test_project)
     check_cells_equal(cells, test_cells)
 
 
@@ -867,7 +831,28 @@ def check_cells_equal(actual_cells, expected_cells) -> None:
 
     for index in chain(range(3, 6), range(7, 21)):
         field = f"f{index}"
-        assert getattr(actual_cells, field) == getattr(expected_cells, field)
+        if index != 14:
+            assert getattr(actual_cells, field) == getattr(expected_cells, field)
+        else:
+            mocked_matlab_future = mock.MagicMock()
+            mocked_engine = mock.MagicMock()
+            mocked_matlab_future.result.return_value = mocked_engine
+            with mock.patch.object(
+                RATapi.wrappers.MatlabWrapper,
+                "loader",
+                mocked_matlab_future,
+            ), mock.patch.object(RATapi.rat_core, "DylibEngine", mock.MagicMock()), mock.patch.object(
+                RATapi.inputs,
+                "get_python_handle",
+                mock.MagicMock(return_value=dummy_function),
+            ), mock.patch.object(
+                RATapi.wrappers.MatlabWrapper,
+                "getHandle",
+                mock.MagicMock(return_value=dummy_function),
+            ), mock.patch.object(
+                RATapi.wrappers.DylibWrapper, "getHandle", mock.MagicMock(return_value=dummy_function)
+            ):
+                assert list(getattr(actual_cells, field)) == getattr(expected_cells, field)
 
 
 def check_controls_equal(actual_controls, expected_controls) -> None:

--- a/tests/test_inputs.py
+++ b/tests/test_inputs.py
@@ -829,30 +829,27 @@ def check_cells_equal(actual_cells, expected_cells) -> None:
         "NaN" if np.isnan(el) else el for entry in actual_cells.f6 for el in entry
     ] == ["NaN" if np.isnan(el) else el for entry in expected_cells.f6 for el in entry]
 
-    for index in chain(range(3, 6), range(7, 21)):
+    mocked_matlab_future = mock.MagicMock()
+    mocked_engine = mock.MagicMock()
+    mocked_matlab_future.result.return_value = mocked_engine
+    with mock.patch.object(
+        RATapi.wrappers.MatlabWrapper,
+        "loader",
+        mocked_matlab_future,
+    ), mock.patch.object(RATapi.rat_core, "DylibEngine", mock.MagicMock()), mock.patch.object(
+        RATapi.inputs,
+        "get_python_handle",
+        mock.MagicMock(return_value=dummy_function),
+    ), mock.patch.object(
+        RATapi.wrappers.MatlabWrapper,
+        "getHandle",
+        mock.MagicMock(return_value=dummy_function),
+    ), mock.patch.object(RATapi.wrappers.DylibWrapper, "getHandle", mock.MagicMock(return_value=dummy_function)):
+        assert list(actual_cells.f14) == expected_cells.f14
+
+    for index in chain(range(3, 6), range(7, 14), range(15, 21)):
         field = f"f{index}"
-        if index != 14:
-            assert getattr(actual_cells, field) == getattr(expected_cells, field)
-        else:
-            mocked_matlab_future = mock.MagicMock()
-            mocked_engine = mock.MagicMock()
-            mocked_matlab_future.result.return_value = mocked_engine
-            with mock.patch.object(
-                RATapi.wrappers.MatlabWrapper,
-                "loader",
-                mocked_matlab_future,
-            ), mock.patch.object(RATapi.rat_core, "DylibEngine", mock.MagicMock()), mock.patch.object(
-                RATapi.inputs,
-                "get_python_handle",
-                mock.MagicMock(return_value=dummy_function),
-            ), mock.patch.object(
-                RATapi.wrappers.MatlabWrapper,
-                "getHandle",
-                mock.MagicMock(return_value=dummy_function),
-            ), mock.patch.object(
-                RATapi.wrappers.DylibWrapper, "getHandle", mock.MagicMock(return_value=dummy_function)
-            ):
-                assert list(getattr(actual_cells, field)) == getattr(expected_cells, field)
+        assert getattr(actual_cells, field) == getattr(expected_cells, field)
 
 
 def check_controls_equal(actual_controls, expected_controls) -> None:


### PR DESCRIPTION
I missed this in the PR to make the pybind classes pickleable. The function handles cannot be pickled so this defers the creation of the handles. The script below uses the languages example to test that all 3 languages pickle correctly and run in a process

```
from multiprocessing import Process

def f(problem_definition, cells, limits, priors, cpp_controls):
    
    start = time.time()
    problem_definition, output_results, bayes_results = RAT.rat_core.RATMain(
    problem_definition,
    cells,
    limits,
    cpp_controls,
    priors,
    )
    end = time.time()
    print(f"Run time is: {end-start}s\n")
        

if __name__ == '__main__':

    project = setup_problem.make_example_problem()
    # project.custom_files.set_fields(0, filename="custom_bilayer.m", language="matlab", path=path)
    # project.custom_files.set_fields(0, filename="custom_bilayer.dll", function_name="customBilayer", language="cpp", path=path)
    controls = RAT.Controls()
    problem_definition, cells, limits, priors, cpp_controls = RAT.inputs.make_input(project, controls)
    
    p = Process(target=f, args=(problem_definition, cells, limits, priors, cpp_controls,))
    p.start()
    p.join()
```
