### PR TITLE
Fixes failing test on python 3.13 and ensure macOS uses 3.12

### DIFF
--- a/.github/workflows/build_wheel.yml
+++ b/.github/workflows/build_wheel.yml
@@ -62,6 +62,7 @@ jobs:
           # of local package.
           mkdir tmp
           cp -r tests tmp/tests/
+          export PATH="$pythonLocation:$PATH"
           CIBW_TEST_COMMAND='cd ${pwd}/tmp && python -m pytest tests'
           echo "CIBW_TEST_COMMAND=${CIBW_TEST_COMMAND}" >> $GITHUB_ENV
           python -m pip install cibuildwheel==2.16.5

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -20,7 +20,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-13]
-        version: ["3.9", "3.13"]
+        version: ["3.9", "3.x"]
     defaults:
       run:
         shell: bash -l {0}

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -20,7 +20,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-13]
-        version: ["3.9", "3.12"]
+        version: ["3.9", "3.13"]
     defaults:
       run:
         shell: bash -l {0}

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -20,7 +20,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-13]
-        version: ["3.9", "3.x"]
+        version: ["3.9", "3.13"]
     defaults:
       run:
         shell: bash -l {0}

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -52,5 +52,6 @@ jobs:
           sudo apt install libomp-dev
       - name: Install and Test with pytest
         run: |
+          export PATH="$pythonLocation:$PATH"
           python -m pip install -e .[Dev]
           pytest tests/ --cov=RATapi --cov-report=term

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -1122,8 +1122,9 @@ def test_write_script(project, request, temp_dir, input_filename: str) -> None:
     assert script_path.exists()
 
     # Test we get the project object we expect when running the script
-    exec(script_path.read_text())
-    new_project = locals()["problem"]
+    local_dict = {}
+    exec(script_path.read_text(), globals(), local_dict)
+    new_project = local_dict["problem"]
 
     for class_list in RATapi.project.class_lists:
         assert getattr(new_project, class_list) == getattr(test_project, class_list)


### PR DESCRIPTION
Added a workaround for MacOS runner ignoring the given python version for the test and fixed a test that was failing on 3.13. The python version is still capped at 3.12 because ubuntu and windows runner are still stuck at 3.12 