### PR TITLE
Fixes bug where "fitParams" outputs only one value

### DIFF
--- a/cpp/rat.cpp
+++ b/cpp/rat.cpp
@@ -1145,7 +1145,7 @@ OutputResult OutputResultFromStruct6T(const RAT::struct6_T result)
         output_result.fitNames.append(str);
     }    
 
-    output_result.fitParams = py::array_t<real_T>(result.fitParams.size(1));
+    output_result.fitParams = py::array_t<real_T>(result.fitParams.size(0));
     auto buffer = output_result.fitParams.request();
     std::memcpy(buffer.ptr, result.fitParams.data(), output_result.fitParams.size()*sizeof(real_T));
 


### PR DESCRIPTION
Could you please confirm the following:

- On the current `main`, the results for the examples contains an array `fitNames` of length >=1, and an array `fitParams` of length 1.
- On this branch, the length of `fitParams` is always the same as that of `fitNames`.