### PR TITLE
Improves `Project.save`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,9 @@ __pycache__/
 .idea
 .vscode
 
+# direnv
+.envrc
+
 # Unit test / coverage reports
 htmlcov/
 .coverage

--- a/RATapi/project.py
+++ b/RATapi/project.py
@@ -7,7 +7,6 @@ import json
 import warnings
 from enum import Enum
 from pathlib import Path
-from sys import version_info
 from textwrap import indent
 from typing import Annotated, Any, Callable, Union
 
@@ -972,28 +971,15 @@ def try_relative_to(path: Path, relative_to: Path) -> Path:
     abs_path = Path(path).resolve()
     abs_base = Path(relative_to).resolve()
 
-    # 'walking up' paths is only added in Python 3.12
-    if version_info.minor < 12:
-        try:
-            relative_path = abs_path.relative_to(abs_base)
-        except ValueError as err:
-            warnings.warn(
-                "Could not save a custom file path as relative to the project directory. "
-                "This may mean the project may not open on other devices. "
-                f"Error message: {err}",
-                stacklevel=2,
-            )
-            return abs_path
-    else:
-        try:
-            relative_path = abs_path.relative_to(abs_base, walk_up=True)
-        except ValueError as err:
-            warnings.warn(
-                "Could not save a custom file path as relative to the project directory. "
-                "This may mean the project may not open on other devices. "
-                f"Error message: {err}",
-                stacklevel=2,
-            )
-            return abs_path
+    try:
+        relative_path = abs_path.relative_to(abs_base)
+    except ValueError:
+        warnings.warn(
+            "Could not save custom file path as relative to the project directory. "
+            "To ensure that your project works on other devices, make sure your custom files "
+            "are in a subfolder of the project save location.",
+            stacklevel=2,
+        )
+        return abs_path
 
     return relative_path

--- a/RATapi/project.py
+++ b/RATapi/project.py
@@ -837,18 +837,17 @@ from numpy import array, empty, inf
             + "\n)"
         )
 
-    def save(self, filepath: Union[str, Path], filename: str = "project"):
+    def save(self, filepath: Union[str, Path] = "./project.json"):
         """Save a project to a JSON file.
 
         Parameters
         ----------
         filepath : str or Path
-            The path in which the project will be written.
-        filename : str
-            The name of the generated project file.
+            The path to where the project file will be written.
 
         """
-        filepath = Path(filepath)
+        filepath = Path(filepath).with_suffix(".json")
+
         json_dict = {}
         for field in self.model_fields:
             attr = getattr(self, field)
@@ -882,8 +881,7 @@ from numpy import array, empty, inf
             else:
                 json_dict[field] = attr
 
-        file = Path(filepath, f"{filename.removesuffix('.json')}.json")
-        file.write_text(json.dumps(json_dict))
+        filepath.write_text(json.dumps(json_dict))
 
     @classmethod
     def load(cls, path: Union[str, Path]) -> "Project":
@@ -979,17 +977,23 @@ def try_relative_to(path: Path, relative_to: Path) -> Path:
         try:
             relative_path = abs_path.relative_to(abs_base)
         except ValueError as err:
-            warnings.warn("Could not save a custom file path as relative to the project directory. "
-                          "This may mean the project may not open on other devices. "
-                          f"Error message: {err}", stacklevel=2)
-            return abs_path 
+            warnings.warn(
+                "Could not save a custom file path as relative to the project directory. "
+                "This may mean the project may not open on other devices. "
+                f"Error message: {err}",
+                stacklevel=2,
+            )
+            return abs_path
     else:
         try:
-            relative_path = abs_path.relative_to(abs_base, walk_up = True)
+            relative_path = abs_path.relative_to(abs_base, walk_up=True)
         except ValueError as err:
-            warnings.warn("Could not save a custom file path as relative to the project directory. "
-                          "This may mean the project may not open on other devices. "
-                          f"Error message: {err}", stacklevel=2)
-            return abs_path 
+            warnings.warn(
+                "Could not save a custom file path as relative to the project directory. "
+                "This may mean the project may not open on other devices. "
+                f"Error message: {err}",
+                stacklevel=2,
+            )
+            return abs_path
 
     return relative_path

--- a/RATapi/project.py
+++ b/RATapi/project.py
@@ -870,7 +870,7 @@ from numpy import array, empty, inf
                         "name": item.name,
                         "filename": item.filename,
                         "language": item.language,
-                        "path": str(try_relative_to(item.path, filepath)),
+                        "path": try_relative_to(item.path, filepath),
                     }
 
                 json_dict["custom_files"] = [make_custom_file_dict(file) for file in attr]
@@ -951,7 +951,7 @@ from numpy import array, empty, inf
         return wrapped_func
 
 
-def try_relative_to(path: Path, relative_to: Path) -> Path:
+def try_relative_to(path: Path, relative_to: Path) -> str:
     """Attempt to create a relative path and warn the user if it isn't possible.
 
     Parameters
@@ -963,7 +963,7 @@ def try_relative_to(path: Path, relative_to: Path) -> Path:
 
     Returns
     -------
-    Path
+    str
         The relative path if successful, else the absolute path.
 
     """

--- a/RATapi/project.py
+++ b/RATapi/project.py
@@ -967,19 +967,16 @@ def try_relative_to(path: Path, relative_to: Path) -> Path:
         The relative path if successful, else the absolute path.
 
     """
-    # we use the absolute paths to resolve symlinks and so on
-    abs_path = Path(path).resolve()
-    abs_base = Path(relative_to).resolve()
-
-    try:
-        relative_path = abs_path.relative_to(abs_base)
-    except ValueError:
+    path = Path(path)
+    relative_to = Path(relative_to)
+    if path.is_relative_to(relative_to):
+        return str(path.relative_to(relative_to))
+    else:
         warnings.warn(
-            "Could not save custom file path as relative to the project directory. "
-            "To ensure that your project works on other devices, make sure your custom files "
+            "Could not save custom file path as relative to the project directory, "
+            "which means that it may not work on other devices."
+            "If you would like to share your project, make sure your custom files "
             "are in a subfolder of the project save location.",
             stacklevel=2,
         )
-        return abs_path
-
-    return relative_path
+        return str(path.resolve())

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -1578,20 +1578,19 @@ def test_relative_paths():
     with tempfile.TemporaryDirectory() as tmp:
         data_path = Path(tmp, "data/myfile.dat")
 
-        assert RATapi.project.try_relative_to(data_path, tmp) == Path("./data/myfile.dat")
+        assert RATapi.project.try_relative_to(data_path, tmp) == "data/myfile.dat"
 
 
-def test_relative_paths_version():
+def test_relative_paths_warning():
     """Test that we get a warning for trying to walk up paths."""
 
     data_path = "/tmp/project/data/mydata.dat"
     relative_path = "/tmp/project/project_path/myproj.dat"
 
     with pytest.warns(
-        match="Could not save custom file path as relative to the project directory. "
-        "To ensure that your project works on other devices, make sure your custom files "
-        "are in a subfolder of the project save location."
+        match="Could not save custom file path as relative to the project directory, "
+        "which means that it may not work on other devices."
+        "If you would like to share your project, make sure your custom files "
+        "are in a subfolder of the project save location.",
     ):
-        assert (
-            RATapi.project.try_relative_to(data_path, relative_path) == Path("/tmp/project/data/mydata.dat").resolve()
-        )
+        assert RATapi.project.try_relative_to(data_path, relative_path) == "/tmp/project/data/mydata.dat"

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -4,7 +4,6 @@ import copy
 import tempfile
 import warnings
 from pathlib import Path
-from sys import version_info
 from typing import Callable
 
 import numpy as np
@@ -1574,7 +1573,7 @@ def test_save_load(project, request):
 
 
 def test_relative_paths():
-    """Test that ``try_relative_to`` correctly creates relative paths."""
+    """Test that ``try_relative_to`` correctly creates relative paths to subfolders."""
 
     with tempfile.TemporaryDirectory() as tmp:
         data_path = Path(tmp, "data/myfile.dat")
@@ -1583,19 +1582,16 @@ def test_relative_paths():
 
 
 def test_relative_paths_version():
-    """Test that we only walk up paths on Python 3.12 or greater."""
+    """Test that we get a warning for trying to walk up paths."""
 
     data_path = "/tmp/project/data/mydata.dat"
     relative_path = "/tmp/project/project_path/myproj.dat"
 
-    if version_info.minor >= 12:
-        with warnings.catch_warnings():
-            warnings.simplefilter("error")
-            assert RATapi.project.try_relative_to(data_path, relative_path) == Path("../../data/mydata.dat")
-    else:
-        with pytest.warns(
-            match="Could not save a custom file path as relative to the project directory. "
-            "This may mean the project may not open on other devices. "
-            "Error message:"
-        ):
-            assert RATapi.project.try_relative_to(data_path, relative_path) == Path("/tmp/project/data/mydata.dat")
+    with pytest.warns(
+        match="Could not save custom file path as relative to the project directory. "
+        "To ensure that your project works on other devices, make sure your custom files "
+        "are in a subfolder of the project save location."
+    ):
+        assert (
+            RATapi.project.try_relative_to(data_path, relative_path) == Path("/tmp/project/data/mydata.dat").resolve()
+        )

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -1578,7 +1578,7 @@ def test_relative_paths():
     with tempfile.TemporaryDirectory() as tmp:
         data_path = Path(tmp, "data/myfile.dat")
 
-        assert RATapi.project.try_relative_to(data_path, tmp) == "data/myfile.dat"
+        assert Path(RATapi.project.try_relative_to(data_path, tmp)) == Path("data/myfile.dat")
 
 
 def test_relative_paths_warning():
@@ -1593,4 +1593,7 @@ def test_relative_paths_warning():
         "If you would like to share your project, make sure your custom files "
         "are in a subfolder of the project save location.",
     ):
-        assert RATapi.project.try_relative_to(data_path, relative_path) == "/tmp/project/data/mydata.dat"
+        assert (
+            Path(RATapi.project.try_relative_to(data_path, relative_path))
+            == Path("/tmp/project/data/mydata.dat").resolve()
+        )

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -1559,10 +1559,11 @@ def test_save_load(project, request):
 
     with tempfile.TemporaryDirectory() as tmp:
         # ignore relative path warnings
+        path = Path(tmp, "project.json")
         with warnings.catch_warnings():
             warnings.simplefilter("ignore")
-            original_project.save(tmp)
-        converted_project = RATapi.Project.load(Path(tmp, "project.json"))
+            original_project.save(path)
+        converted_project = RATapi.Project.load(path)
 
     # resolve custom files in case the original project had unresolvable relative paths
     for file in original_project.custom_files:
@@ -1583,7 +1584,7 @@ def test_relative_paths():
 
 def test_relative_paths_version():
     """Test that we only walk up paths on Python 3.12 or greater."""
-    
+
     data_path = "/tmp/project/data/mydata.dat"
     relative_path = "/tmp/project/project_path/myproj.dat"
 
@@ -1591,8 +1592,10 @@ def test_relative_paths_version():
         with warnings.catch_warnings():
             warnings.simplefilter("error")
             assert RATapi.project.try_relative_to(data_path, relative_path) == Path("../../data/mydata.dat")
-    else: 
-        with pytest.warns(match="Could not save a custom file path as relative to the project directory. "
-                          "This may mean the project may not open on other devices. "
-                          "Error message:"):
+    else:
+        with pytest.warns(
+            match="Could not save a custom file path as relative to the project directory. "
+            "This may mean the project may not open on other devices. "
+            "Error message:"
+        ):
             assert RATapi.project.try_relative_to(data_path, relative_path) == Path("/tmp/project/data/mydata.dat")

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -2,7 +2,9 @@
 
 import copy
 import tempfile
+import warnings
 from pathlib import Path
+from sys import version_info
 from typing import Callable
 
 import numpy as np
@@ -1556,8 +1558,41 @@ def test_save_load(project, request):
     original_project = request.getfixturevalue(project)
 
     with tempfile.TemporaryDirectory() as tmp:
-        original_project.save(tmp)
+        # ignore relative path warnings
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            original_project.save(tmp)
         converted_project = RATapi.Project.load(Path(tmp, "project.json"))
+
+    # resolve custom files in case the original project had unresolvable relative paths
+    for file in original_project.custom_files:
+        file.path = file.path.resolve()
 
     for field in RATapi.Project.model_fields:
         assert getattr(converted_project, field) == getattr(original_project, field)
+
+
+def test_relative_paths():
+    """Test that ``try_relative_to`` correctly creates relative paths."""
+
+    with tempfile.TemporaryDirectory() as tmp:
+        data_path = Path(tmp, "data/myfile.dat")
+
+        assert RATapi.project.try_relative_to(data_path, tmp) == Path("./data/myfile.dat")
+
+
+def test_relative_paths_version():
+    """Test that we only walk up paths on Python 3.12 or greater."""
+    
+    data_path = "/tmp/project/data/mydata.dat"
+    relative_path = "/tmp/project/project_path/myproj.dat"
+
+    if version_info.minor >= 12:
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            assert RATapi.project.try_relative_to(data_path, relative_path) == Path("../../data/mydata.dat")
+    else: 
+        with pytest.warns(match="Could not save a custom file path as relative to the project directory. "
+                          "This may mean the project may not open on other devices. "
+                          "Error message:"):
+            assert RATapi.project.try_relative_to(data_path, relative_path) == Path("/tmp/project/data/mydata.dat")


### PR DESCRIPTION
Fixes #126 by changing the `Project.save` method to do the following:
- Now only takes one parameter, `filepath`, which is the path to the actual file to save to
- Saves custom file paths relative to where the project is saved and loads them accordingly, so that projects are more portable