### PR TITLE
Ensure nChains is greater than 1

### DIFF
--- a/RATapi/controls.py
+++ b/RATapi/controls.py
@@ -118,7 +118,7 @@ class Controls(BaseModel, validate_assignment=True, extra="forbid", use_attribut
     nSamples: int = Field(20000, ge=0)
     """[DREAM] The number of samples in the initial population for each chain."""
 
-    nChains: int = Field(10, gt=0)
+    nChains: int = Field(10, gt=1)
     """[DREAM] The number of Markov chains to use in the algorithm."""
 
     jumpProbability: float = Field(0.5, gt=0.0, lt=1.0)

--- a/tests/test_controls.py
+++ b/tests/test_controls.py
@@ -859,7 +859,7 @@ class TestDream:
     @pytest.mark.parametrize("value", [-5, 0])
     def test_dream_nChains_error(self, value: int) -> None:
         """Tests the nChains setter error in Dream class."""
-        with pytest.raises(pydantic.ValidationError, match="Input should be greater than 0"):
+        with pytest.raises(pydantic.ValidationError, match="Input should be greater than 1"):
             self.dream.nChains = value
 
     def test_control_class_dream_str(self, table_str) -> None:


### PR DESCRIPTION
See RascalSoftware/RAT#376 - DREAM crashes if `nChains` is 1 because it requires multiple chains.