### PR TITLE
Fix chain plots crash if chains are smaller than `maxpoints`

### DIFF
--- a/RATapi/utils/plotting.py
+++ b/RATapi/utils/plotting.py
@@ -833,7 +833,9 @@ def plot_chain(
     """
     chain = results.chain
     nsimulations, nplots = chain.shape
-    skip = floor(nsimulations / maxpoints)  # to evenly distribute points plotted
+    # skip is to evenly distribute points plotted
+    # all points will be plotted if maxpoints < nsimulations
+    skip = max(floor(nsimulations / maxpoints), 1)
 
     # convert names to indices if given
     fitname_to_index = partial(name_to_index, names=results.fitNames)


### PR DESCRIPTION
Currently, the chain plots crash if `maxpoints` is larger than the length of the chain. This is because we use a `skip` variable:
`skip = floor(nsimulations / maxpoints)`
which gives us spacing so that the sampled points in the plot are evenly distributed across the chain. However, if `nsimulations < maxpoints`, then `skip` will be 0, which causes a crash when we try to use it for a range skip.

We fix this by replacing the above line with
`skip = max(floor(nsimulations / maxpoints), 1)`
so that `skip` is set to 1 (i.e. the entire chain is plotted) when `nsimulations < maxpoints`.

To reproduce:
```python
import RATapi as RAT

project, _ = RAT.examples.DSPC_standard_layers()
# broken for any nSamples < 15000 (the default value of maxpoints)
controls = RAT.Controls(procedure="dream", nSamples=1000)

_, results = RAT.run(project, controls)
RAT.utils.plotting.plot_chain(results)
# crash
```