### PR TITLE
Add a python equivalent to MATLABs smoothdata and use in Bayes plots

### DIFF
--- a/ratapi/utils/plotting.py
+++ b/ratapi/utils/plotting.py
@@ -826,9 +826,7 @@ def plot_one_hist(
     sd_y = np.std(parameter_chain)
 
     if smooth:
-        if sigma is None:
-            sigma = sd_y / 2
-        counts = gaussian_filter1d(counts, sigma)
+        counts = moving_avg(counts)
     axes.hist(
         bins[:-1],
         bins,
@@ -1233,3 +1231,30 @@ def plot_bayes(project: ratapi.Project, results: ratapi.outputs.BayesResults):
         plot_corner(results)
     else:
         raise ValueError("Bayes plots are only available for the results of Bayesian analysis (NS or DREAM)")
+
+
+def moving_avg(data: np.ndarray, window_size: int = 8) -> list[float]:
+    """Calculate the moving average of an array with a given window size.
+
+    This is a python equivalent to MATLABs smoothdata(A, 'movmean')
+
+    Parameters
+    ----------
+    data : np.ndarray
+           The input array to smooth
+    window_size : int
+                  The window slides down the length of the vector,
+                  computing an average over the elements within each window.
+
+    """
+    i = 0
+    moving_averages = []
+
+    while i < len(data):
+        start_window_ind = floor(float(i - window_size / 2)) if i - window_size / 2 > 0 else 0
+        end_window_ind = floor(float(i + window_size / 2)) if i + window_size / 2 < len(data) else len(data)
+        window_average = np.sum(data[start_window_ind:end_window_ind]) / (end_window_ind + 0 - start_window_ind)
+        moving_averages.append(window_average)
+        i += 1
+
+    return moving_averages

--- a/ratapi/utils/plotting.py
+++ b/ratapi/utils/plotting.py
@@ -1132,7 +1132,6 @@ def plot_hists(
             results,
             i,
             smooth=smooth,
-            sigma=sigma,
             estimated_density=estimated_density.get(i),
             axes=ax,
             **hist_settings,
@@ -1247,7 +1246,11 @@ def moving_average(data: np.ndarray, window_size: int = 8) -> list[float]:
                   computing an average over the elements within each window.
 
     """
-    assert 0 <= window_size <= len(data)
+    if not 0 <= window_size <= len(data):
+        raise ValueError(
+            "The moving average window size is out of range. Please change to a positive integer which "
+            "does not exceed the number of histogram bins."
+        )
     moving_averages = []
 
     for i in range(len(data)):
@@ -1255,6 +1258,5 @@ def moving_average(data: np.ndarray, window_size: int = 8) -> list[float]:
         end_window_ind = floor(float(i + window_size / 2)) if i + window_size / 2 < len(data) else len(data)
         window_average = np.sum(data[start_window_ind:end_window_ind]) / (end_window_ind + 0 - start_window_ind)
         moving_averages.append(window_average)
-        i += 1
 
     return moving_averages

--- a/ratapi/utils/plotting.py
+++ b/ratapi/utils/plotting.py
@@ -763,7 +763,7 @@ def plot_one_hist(
     results: ratapi.outputs.BayesResults,
     param: int | str,
     smooth: bool = True,
-    sigma: float | None = None,
+    window_size: int = 8,
     estimated_density: Literal["normal", "lognor", "kernel", None] = None,
     axes: Axes | None = None,
     block: bool = False,
@@ -783,9 +783,9 @@ def plot_one_hist(
     smooth : bool, default True
         Whether to apply Gaussian smoothing to the histogram.
         Defaults to True.
-    sigma: float or None, default None
-        If given, is used as the sigma-parameter for the Gaussian smoothing.
-        If None, the default (1/3rd of parameter chain standard deviation) is used.
+    window_size : int, default 8
+        The width of the smoothing window centered around the element being averaged.
+        The window moves down the length of the data, computing an average over the elements within each window.
     estimated_density : 'normal', 'lognor', 'kernel' or None, default None
         If None (default), ignore. Else, add an estimated density
         of the given form on top of the histogram by the following estimations:
@@ -826,7 +826,7 @@ def plot_one_hist(
     sd_y = np.std(parameter_chain)
 
     if smooth:
-        counts = moving_avg(counts)
+        counts = moving_average(counts, window_size=window_size)
     axes.hist(
         bins[:-1],
         bins,
@@ -1233,7 +1233,7 @@ def plot_bayes(project: ratapi.Project, results: ratapi.outputs.BayesResults):
         raise ValueError("Bayes plots are only available for the results of Bayesian analysis (NS or DREAM)")
 
 
-def moving_avg(data: np.ndarray, window_size: int = 8) -> list[float]:
+def moving_average(data: np.ndarray, window_size: int = 8) -> list[float]:
     """Calculate the moving average of an array with a given window size.
 
     This is a python equivalent to MATLABs smoothdata(A, 'movmean')
@@ -1247,10 +1247,10 @@ def moving_avg(data: np.ndarray, window_size: int = 8) -> list[float]:
                   computing an average over the elements within each window.
 
     """
-    i = 0
+    assert 0 <= window_size <= len(data)
     moving_averages = []
 
-    while i < len(data):
+    for i in range(len(data)):
         start_window_ind = floor(float(i - window_size / 2)) if i - window_size / 2 > 0 else 0
         end_window_ind = floor(float(i + window_size / 2)) if i + window_size / 2 < len(data) else len(data)
         window_average = np.sum(data[start_window_ind:end_window_ind]) / (end_window_ind + 0 - start_window_ind)

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -495,3 +495,21 @@ def test_extract_plot_data(data) -> None:
 
     with pytest.raises(ValueError, match=r"Parameter `shift_value` must be between 0 and 100"):
         RATplot._extract_plot_data(data, False, True, 100.5)
+
+
+def test_moving_average() -> None:
+    """Test the moving_average function."""
+    data_to_average = np.arange(0, 20)
+    mov_avg = RATplot.moving_average(data_to_average)
+    assert mov_avg == [1.5, 2.0, 2.5, 3.0, 3.5, 4.5, 5.5, 6.5, 7.5, 8.5, 9.5, 10.5, 11.5, 12.5, 13.5, 14.5, 15.5, 16.0,
+                       16.5, 17.0]
+
+    mov_avg = RATplot.moving_average(data_to_average, window_size=2)
+    assert mov_avg == [0.0, 0.5, 1.5, 2.5, 3.5, 4.5, 5.5, 6.5, 7.5, 8.5, 9.5, 10.5, 11.5, 12.5, 13.5, 14.5, 15.5, 16.5,
+                       17.5, 18.5]
+
+    with pytest.raises(AssertionError):
+        RATplot.moving_average(data_to_average, window_size=-1)
+
+    with pytest.raises(AssertionError):
+        RATplot.moving_average(data_to_average, window_size=len(data_to_average)+1)

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -501,15 +501,55 @@ def test_moving_average() -> None:
     """Test the moving_average function."""
     data_to_average = np.arange(0, 20)
     mov_avg = RATplot.moving_average(data_to_average)
-    assert mov_avg == [1.5, 2.0, 2.5, 3.0, 3.5, 4.5, 5.5, 6.5, 7.5, 8.5, 9.5, 10.5, 11.5, 12.5, 13.5, 14.5, 15.5, 16.0,
-                       16.5, 17.0]
+    assert mov_avg == [
+        1.5,
+        2.0,
+        2.5,
+        3.0,
+        3.5,
+        4.5,
+        5.5,
+        6.5,
+        7.5,
+        8.5,
+        9.5,
+        10.5,
+        11.5,
+        12.5,
+        13.5,
+        14.5,
+        15.5,
+        16.0,
+        16.5,
+        17.0,
+    ]
 
     mov_avg = RATplot.moving_average(data_to_average, window_size=2)
-    assert mov_avg == [0.0, 0.5, 1.5, 2.5, 3.5, 4.5, 5.5, 6.5, 7.5, 8.5, 9.5, 10.5, 11.5, 12.5, 13.5, 14.5, 15.5, 16.5,
-                       17.5, 18.5]
+    assert mov_avg == [
+        0.0,
+        0.5,
+        1.5,
+        2.5,
+        3.5,
+        4.5,
+        5.5,
+        6.5,
+        7.5,
+        8.5,
+        9.5,
+        10.5,
+        11.5,
+        12.5,
+        13.5,
+        14.5,
+        15.5,
+        16.5,
+        17.5,
+        18.5,
+    ]
 
     with pytest.raises(AssertionError):
         RATplot.moving_average(data_to_average, window_size=-1)
 
     with pytest.raises(AssertionError):
-        RATplot.moving_average(data_to_average, window_size=len(data_to_average)+1)
+        RATplot.moving_average(data_to_average, window_size=len(data_to_average) + 1)

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -548,8 +548,8 @@ def test_moving_average() -> None:
         18.5,
     ]
 
-    with pytest.raises(AssertionError):
+    with pytest.raises(ValueError):
         RATplot.moving_average(data_to_average, window_size=-1)
 
-    with pytest.raises(AssertionError):
+    with pytest.raises(ValueError):
         RATplot.moving_average(data_to_average, window_size=len(data_to_average) + 1)


### PR DESCRIPTION
This PR fixes the issue with the Bayes plots smoothing not functioning correctly for background parameters. The issue comes from the use of `scipy.ndimage.gaussian_filter1d` instead of a moving average smoothing as is used in MATLAB: `smoothdata(N, 'movmean')`.

This PR fixes the issue by implimenting a python version of `smoothdata` and the function has been benchmarked against results from MATLAB. 
`smoothdata` automatically calculates the averaging window to use but there is no real explanation on how this is calculated. This has been set to 8 as default as this is the value used by MATLAB for RAT data most commonly.

Benchmark for noisy data:
<img width="973" height="672" alt="MATLAB vs Python smoothing" src="https://github.com/user-attachments/assets/18c90c3b-6631-4f10-b242-d29b67830252" />

Example of new smoothing for Substrate Roughness example:
<img width="926" height="603" alt="image" src="https://github.com/user-attachments/assets/e5b0df8d-7785-4c05-9ee2-5723687faa61" />

Old smoothing:
<img width="2260" height="926" alt="python Gaussian smoothing" src="https://github.com/user-attachments/assets/e593e8ee-a1d4-4aed-bead-00f26a8ec15a" />

New smoothing:
<img width="2254" height="940" alt="python mov_avg smoothing" src="https://github.com/user-attachments/assets/1307ddda-0bc1-4b81-b377-431d1cf40bd8" />


